### PR TITLE
Fixed cached_property sensor not updating bug & cleanups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-          pip install "homeassistant>=2026.4.0"
 
       - name: Run pyright validation
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ home-assistant_v2.db
 home-assistant_v2.db-shm
 home-assistant_v2.db-wal
 home-assistant_v2.db.backup
+.devcontainer/config/.ha_run.lock

--- a/custom_components/polleninformation_at/const.py
+++ b/custom_components/polleninformation_at/const.py
@@ -1,6 +1,6 @@
 DOMAIN = "polleninformation_at"
 INTEGRATION_NAME = "Polleninformation.at"
-INTEGRATION_AUTHOR = "Christian Kadluba"
+INTEGRATION_DEVICE_MANUFACTURER = "Christian Kadluba (data provided by www.polleninformation.at)"
 PLATFORMS = ["sensor"]
 
 POLLEN_TYPES = {

--- a/custom_components/polleninformation_at/manifest.json
+++ b/custom_components/polleninformation_at/manifest.json
@@ -12,5 +12,5 @@
     "requirements": [
         "aiohttp"
     ],
-    "version": "1.0.0"
+    "version": "1.0.1"
 }

--- a/custom_components/polleninformation_at/sensor.py
+++ b/custom_components/polleninformation_at/sensor.py
@@ -55,13 +55,13 @@ class PollenSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
         self._attr_native_unit_of_measurement = "level"
         self._attr_available = True
 
-    @cached_property
+    @property
     def native_value(self) -> int | None:
         """Return the current contamination level."""
         data = self._get_contamination_entry()
         return data.get("contamination_1") if data else None
 
-    @cached_property
+    @property
     def extra_state_attributes(self) -> dict:
         """Return additional sensor attributes."""
         data = self._get_contamination_entry()

--- a/custom_components/polleninformation_at/sensor.py
+++ b/custom_components/polleninformation_at/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from custom_components.polleninformation_at.const import (
     DOMAIN,
     ICON_FLOWER_POLLEN,
-    INTEGRATION_AUTHOR,
+    INTEGRATION_DEVICE_MANUFACTURER,
     INTEGRATION_NAME,
     POLLEN_TYPES,
 )
@@ -44,7 +44,7 @@ class PollenSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, "polleninformation_at")},
             name=INTEGRATION_NAME,
-            manufacturer=INTEGRATION_AUTHOR,
+            manufacturer=INTEGRATION_DEVICE_MANUFACTURER,
             entry_type=DeviceEntryType.SERVICE,
         )
         self._attr_has_entity_name = True

--- a/custom_components/polleninformation_at/sensor.py
+++ b/custom_components/polleninformation_at/sensor.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
     async_add_entities(sensors)
 
 
-class PollenSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
+class PollenSensor(CoordinatorEntity, SensorEntity):
     """Polleninformation.at sensor backed by the integration coordinator."""
 
     def __init__(self, coordinator, pollen_type, pollen_id, pollen_name):

--- a/custom_components/polleninformation_at/sensor.py
+++ b/custom_components/polleninformation_at/sensor.py
@@ -54,13 +54,13 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "level"
 
-    @property
+    @property  # pyright: ignore[reportIncompatibleMethodOverride]
     def native_value(self) -> int | None:
         """Return the current contamination level."""
         data = self._get_contamination_entry()
         return data.get("contamination_1") if data else None
 
-    @property
+    @property  # pyright: ignore[reportIncompatibleMethodOverride]
     def extra_state_attributes(self) -> dict:
         """Return additional sensor attributes."""
         data = self._get_contamination_entry()

--- a/custom_components/polleninformation_at/sensor.py
+++ b/custom_components/polleninformation_at/sensor.py
@@ -53,7 +53,6 @@ class PollenSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
         self._attr_icon = ICON_FLOWER_POLLEN
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "level"
-        self._attr_available = True
 
     @property
     def native_value(self) -> int | None:

--- a/custom_components/polleninformation_at/sensor.py
+++ b/custom_components/polleninformation_at/sensor.py
@@ -30,8 +30,10 @@ async def async_setup_entry(
     ]
     async_add_entities(sensors)
 
-
-class PollenSensor(CoordinatorEntity, SensorEntity):
+# Pyright is too strict here: CoordinatorEntity and SensorEntity have incompatible definitions for member available
+class PollenSensor( # pyright: ignore[reportIncompatibleVariableOverride]
+    CoordinatorEntity, 
+    SensorEntity):
     """Polleninformation.at sensor backed by the integration coordinator."""
 
     def __init__(self, coordinator, pollen_type, pollen_id, pollen_name):
@@ -54,14 +56,16 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = "level"
 
-    @property  # pyright: ignore[reportIncompatibleMethodOverride]
-    def native_value(self) -> int | None:
+    # Pyright is too strict here: we cannot use @cached_property because HA would not update the value then
+    @property  # pyright: ignore[reportIncompatibleVariableOverride]
+    def native_value(self) -> int | None: # pyright: ignore[reportIncompatibleVariableOverride]
         """Return the current contamination level."""
         data = self._get_contamination_entry()
         return data.get("contamination_1") if data else None
 
-    @property  # pyright: ignore[reportIncompatibleMethodOverride]
-    def extra_state_attributes(self) -> dict:
+    # Pyright is too strict here: we cannot use @cached_property because HA would not update the value then
+    @property  # pyright: ignore[reportIncompatibleVariableOverride]
+    def extra_state_attributes(self) -> dict: # pyright: ignore[reportIncompatibleVariableOverride]
         """Return additional sensor attributes."""
         data = self._get_contamination_entry()
         if not data:

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,6 @@
     "name": "Polleninformation.at",
     "render_readme": true,
     "homeassistant": "2026.4.0",
-    "country": "AT"
+    "country": "AT",
+    "icon": "mdi:flower-pollen"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,5 @@
     "name": "Polleninformation.at",
     "render_readme": true,
     "homeassistant": "2026.4.0",
-    "country": "AT",
-    "icon": "mdi:flower-pollen"
+    "country": "AT"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,4 @@ pytest-asyncio>=0.21.0
 python-dotenv>=0.19.0
 aiohttp>=3.8.0
 voluptuous>=0.13.0
+homeassistant>=2026.4.0


### PR DESCRIPTION
* Changed sensor class properties from cached_property to property (sensor was not updating otherwise)
* Added manufacturer string to include notice "data provided by polleninformation.at"
* Added .devcontainer/config/.ha_run.lock to .gitignore
* Removed illegal property `icon` from hacs.json
* Bumped patch version