### PR TITLE
Use HA system lang as API parameter

### DIFF
--- a/custom_components/polleninformation_at/api.py
+++ b/custom_components/polleninformation_at/api.py
@@ -21,17 +21,15 @@ class PollenApi:
         self._api_key = api_key
         self._raw_response = None
 
-    @property
-    def raw_response(self):  # noqa: ANN201
-        """Return the latest raw API response."""
-        return self._raw_response
+        self._lang = (
+            self.hass.config.language
+            if self.hass.config.language in ["de", "en"]
+            else "en"
+        )
+        self._latitude = self.hass.config.latitude
+        self._longitude = self.hass.config.longitude
 
-    async def async_update(self):  # noqa: ANN201
-        """Query data from API and store the raw response."""
-        latitude = self.hass.config.latitude
-        longitude = self.hass.config.longitude
-
-        if latitude is None or longitude is None:
+        if self._latitude is None or self._longitude is None:
             msg = "Home location is not configured."
             raise ValueError(msg)
         if not self._api_key:
@@ -40,30 +38,41 @@ class PollenApi:
 
         endpoint = (
             "https://www.polleninformation.at/api/forecast/public"
-            "?country=AT&lang=de&latitude={latitude}&longitude={longitude}"
+            "?country=AT&lang={lang}&latitude={latitude}&longitude={longitude}"
             "&apikey={apikey}"
         )
-        url = endpoint.format(
-            latitude=latitude,
-            longitude=longitude,
+        self._url = endpoint.format(
+            latitude=self._latitude,
+            longitude=self._longitude,
+            lang=self._lang,
             apikey=self._api_key,
         )
-        redacted_url = endpoint.format(
+        self._redacted_url = endpoint.format(
             latitude="<REDACTED>",
             longitude="<REDACTED>",
+            lang=self._lang,
             apikey="<REDACTED>",
         )
-        _LOGGER.debug("Fetching data from URL: %s", redacted_url)
+
+    @property
+    def raw_response(self):  # noqa: ANN201
+        """Return the latest raw API response."""
+        return self._raw_response
+
+    async def async_update(self):  # noqa: ANN201
+        """Query data from API and store the raw response."""
+        _LOGGER.debug("Fetching data from URL: %s", self._redacted_url)
+
         try:
             async with (
                 aiohttp.ClientSession() as session,
-                session.get(url, timeout=ClientTimeout(total=10)) as response,
+                session.get(self._url, timeout=ClientTimeout(total=10)) as response,
             ):
                 response.raise_for_status()
                 data = await response.json()
                 self._raw_response = data
                 return data
         except aiohttp.ClientError as err:
-            error_msg = f"Error fetching data from URL: {redacted_url}"
+            error_msg = f"Error fetching data from URL: {self._redacted_url}"
             _LOGGER.exception(error_msg)
             raise RuntimeError(error_msg) from err

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,10 +95,28 @@ class FakeClientSession:
 
 
 class TestPollenApi(unittest.IsolatedAsyncioTestCase):
+    def test_init_sets_supported_system_language_or_english_fallback(self):
+        for system_language, expected_language in (
+            ("de", "de"),
+            ("en", "en"),
+            ("fr", "en"),
+        ):
+            with self.subTest(system_language=system_language):
+                hass = SimpleNamespace(
+                    config=SimpleNamespace(
+                        language=system_language, latitude=48.2082, longitude=16.3738
+                    )
+                )
+
+                api = PollenApi(hass, "test-api-key")
+
+                self.assertEqual(api._lang, expected_language)
+                self.assertIn(f"lang={expected_language}", api._url)
+
     async def test_async_update_sets_state_and_poll_title(self):
         # Arrange
         hass = SimpleNamespace(
-            config=SimpleNamespace(latitude=48.2082, longitude=16.3738)
+            config=SimpleNamespace(language="de", latitude=48.2082, longitude=16.3738)
         )
         api_key = "test-api-key"
         payload = {
@@ -129,7 +147,9 @@ class TestPollenApi(unittest.IsolatedAsyncioTestCase):
 
     async def test_async_update_uses_lat_lon_from_config(self):
         # Arrange
-        hass = SimpleNamespace(config=SimpleNamespace(latitude=47.0, longitude=15.0))
+        hass = SimpleNamespace(
+            config=SimpleNamespace(language="de", latitude=47.0, longitude=15.0)
+        )
         api_key = "test-key"
         payload = {"contamination": []}
         response = FakeResponse(payload)
@@ -150,7 +170,9 @@ class TestPollenApi(unittest.IsolatedAsyncioTestCase):
 
     async def test_async_update_uses_api_key_in_url(self):
         # Arrange
-        hass = SimpleNamespace(config=SimpleNamespace(latitude=47.0, longitude=15.0))
+        hass = SimpleNamespace(
+            config=SimpleNamespace(language="de", latitude=47.0, longitude=15.0)
+        )
         api_key = "my-special-key"
         payload = {"contamination": []}
         response = FakeResponse(payload)
@@ -171,7 +193,7 @@ class TestPollenApi(unittest.IsolatedAsyncioTestCase):
     async def test_async_update_does_not_log_api_key(self):
         # Arrange
         hass = SimpleNamespace(
-            config=SimpleNamespace(latitude=48.2082, longitude=16.3738)
+            config=SimpleNamespace(language="de", latitude=48.2082, longitude=16.3738)
         )
         api_key = "secret-api-key"
         payload = {"contamination": []}
@@ -199,7 +221,9 @@ class TestPollenApi(unittest.IsolatedAsyncioTestCase):
         longitude = 15.0
         api_key = "my-special-key"
         hass = SimpleNamespace(
-            config=SimpleNamespace(latitude=latitude, longitude=longitude)
+            config=SimpleNamespace(
+                language="de", latitude=latitude, longitude=longitude
+            )
         )
         payload = {"contamination": []}
         response = FakeResponse(payload)
@@ -217,12 +241,13 @@ class TestPollenApi(unittest.IsolatedAsyncioTestCase):
         url = session.get.call_args.args[0]
         self.assertIn(f"latitude={latitude}", url)
         self.assertIn(f"longitude={longitude}", url)
+        self.assertIn("lang=de", url)
         self.assertIn(f"apikey={api_key}", url)
 
     async def test_async_update_logs_error_with_redacted_url_and_cause(self):
         # Arrange
         hass = SimpleNamespace(
-            config=SimpleNamespace(latitude=48.2082, longitude=16.3738)
+            config=SimpleNamespace(language="de", latitude=48.2082, longitude=16.3738)
         )
         api_key = "secret-api-key"
         payload = {"contamination": []}

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -51,7 +51,9 @@ class TestPollenApiIntegration(unittest.IsolatedAsyncioTestCase):
         latitude = float(os.getenv("POLLEN_API_TEST_LATITUDE", "48.2082"))
         longitude = float(os.getenv("POLLEN_API_TEST_LONGITUDE", "16.3738"))
         hass = SimpleNamespace(
-            config=SimpleNamespace(latitude=latitude, longitude=longitude)
+            config=SimpleNamespace(
+                language="de", latitude=latitude, longitude=longitude
+            )
         )
         api = pollen_api_class(hass, api_key)
 


### PR DESCRIPTION
* When calling the API set the lang query parameter to the Home Assistant system language when it is "en" or "de". Otherwise default to "en".
* Moved some intializations in PollenApi class to __init__ instead of doing it for every request.
* Added and adapted tests.