### PR TITLE
Use HA system lang as API parameter

### DIFF
--- a/custom_components/polleninformation_at/api.py
+++ b/custom_components/polleninformation_at/api.py
@@ -21,17 +21,15 @@ class PollenApi:
         self._api_key = api_key
         self._raw_response = None
 
-    @property
-    def raw_response(self):  # noqa: ANN201
-        """Return the latest raw API response."""
-        return self._raw_response
+        self._lang = (
+            self.hass.config.language
+            if self.hass.config.language in ["de", "en"]
+            else "en"
+        )
+        self._latitude = self.hass.config.latitude
+        self._longitude = self.hass.config.longitude
 
-    async def async_update(self):  # noqa: ANN201
-        """Query data from API and store the raw response."""
-        latitude = self.hass.config.latitude
-        longitude = self.hass.config.longitude
-
-        if latitude is None or longitude is None:
+        if self._latitude is None or self._longitude is None:
             msg = "Home location is not configured."
             raise ValueError(msg)
         if not self._api_key:
@@ -40,30 +38,41 @@ class PollenApi:
 
         endpoint = (
             "https://www.polleninformation.at/api/forecast/public"
-            "?country=AT&lang=de&latitude={latitude}&longitude={longitude}"
+            "?country=AT&lang={lang}&latitude={latitude}&longitude={longitude}"
             "&apikey={apikey}"
         )
-        url = endpoint.format(
-            latitude=latitude,
-            longitude=longitude,
+        self._url = endpoint.format(
+            latitude=self._latitude,
+            longitude=self._longitude,
+            lang=self._lang,
             apikey=self._api_key,
         )
-        redacted_url = endpoint.format(
+        self._redacted_url = endpoint.format(
             latitude="<REDACTED>",
             longitude="<REDACTED>",
+            lang=self._lang,
             apikey="<REDACTED>",
         )
-        _LOGGER.debug("Fetching data from URL: %s", redacted_url)
+
+    @property
+    def raw_response(self):  # noqa: ANN201
+        """Return the latest raw API response."""
+        return self._raw_response
+
+    async def async_update(self):  # noqa: ANN201
+        """Query data from API and store the raw response."""
+        _LOGGER.debug("Fetching data from URL: %s", self._redacted_url)
+
         try:
             async with (
                 aiohttp.ClientSession() as session,
-                session.get(url, timeout=ClientTimeout(total=10)) as response,
+                session.get(self._url, timeout=ClientTimeout(total=10)) as response,
             ):
                 response.raise_for_status()
                 data = await response.json()
                 self._raw_response = data
                 return data
         except aiohttp.ClientError as err:
-            error_msg = f"Error fetching data from URL: {redacted_url}"
+            error_msg = f"Error fetching data from URL: {self._redacted_url}"
             _LOGGER.exception(error_msg)
             raise RuntimeError(error_msg) from err

--- a/custom_components/polleninformation_at/manifest.json
+++ b/custom_components/polleninformation_at/manifest.json
@@ -13,5 +13,5 @@
         "aiohttp",
         "voluptuous"
     ],
-    "version": "1.5.2"
+    "version": "1.6.0"
 }

--- a/custom_components/polleninformation_at/manifest.json
+++ b/custom_components/polleninformation_at/manifest.json
@@ -13,5 +13,5 @@
         "aiohttp",
         "voluptuous"
     ],
-    "version": "1.5.1"
+    "version": "1.5.2"
 }

--- a/custom_components/polleninformation_at/sensor.py
+++ b/custom_components/polleninformation_at/sensor.py
@@ -272,7 +272,11 @@ class PollenDataExtractor(DataExtractor):
 
     def get_extra_state_attributes(self) -> dict:
         """Return additional sensor attributes."""
-        return {}
+        data = self._get_contamination_entry()
+        poll_title = data.get("poll_title") if data else None
+        return {
+            "poll_title": poll_title,
+        }
 
     def _get_contamination_entry(self) -> dict | None:
         """Extract the contamination entry for this pollen type."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,10 +95,28 @@ class FakeClientSession:
 
 
 class TestPollenApi(unittest.IsolatedAsyncioTestCase):
+    def test_init_sets_supported_system_language_or_english_fallback(self):
+        for system_language, expected_language in (
+            ("de", "de"),
+            ("en", "en"),
+            ("fr", "en"),
+        ):
+            with self.subTest(system_language=system_language):
+                hass = SimpleNamespace(
+                    config=SimpleNamespace(
+                        language=system_language, latitude=48.2082, longitude=16.3738
+                    )
+                )
+
+                api = PollenApi(hass, "test-api-key")
+
+                self.assertEqual(api._lang, expected_language)
+                self.assertIn(f"lang={expected_language}", api._url)
+
     async def test_async_update_sets_state_and_poll_title(self):
         # Arrange
         hass = SimpleNamespace(
-            config=SimpleNamespace(latitude=48.2082, longitude=16.3738)
+            config=SimpleNamespace(language="de", latitude=48.2082, longitude=16.3738)
         )
         api_key = "test-api-key"
         payload = {
@@ -129,7 +147,9 @@ class TestPollenApi(unittest.IsolatedAsyncioTestCase):
 
     async def test_async_update_uses_lat_lon_from_config(self):
         # Arrange
-        hass = SimpleNamespace(config=SimpleNamespace(latitude=47.0, longitude=15.0))
+        hass = SimpleNamespace(
+            config=SimpleNamespace(language="de", latitude=47.0, longitude=15.0)
+        )
         api_key = "test-key"
         payload = {"contamination": []}
         response = FakeResponse(payload)
@@ -150,7 +170,9 @@ class TestPollenApi(unittest.IsolatedAsyncioTestCase):
 
     async def test_async_update_uses_api_key_in_url(self):
         # Arrange
-        hass = SimpleNamespace(config=SimpleNamespace(latitude=47.0, longitude=15.0))
+        hass = SimpleNamespace(
+            config=SimpleNamespace(language="de", latitude=47.0, longitude=15.0)
+        )
         api_key = "my-special-key"
         payload = {"contamination": []}
         response = FakeResponse(payload)
@@ -171,7 +193,7 @@ class TestPollenApi(unittest.IsolatedAsyncioTestCase):
     async def test_async_update_does_not_log_api_key(self):
         # Arrange
         hass = SimpleNamespace(
-            config=SimpleNamespace(latitude=48.2082, longitude=16.3738)
+            config=SimpleNamespace(language="de", latitude=48.2082, longitude=16.3738)
         )
         api_key = "secret-api-key"
         payload = {"contamination": []}
@@ -199,7 +221,9 @@ class TestPollenApi(unittest.IsolatedAsyncioTestCase):
         longitude = 15.0
         api_key = "my-special-key"
         hass = SimpleNamespace(
-            config=SimpleNamespace(latitude=latitude, longitude=longitude)
+            config=SimpleNamespace(
+                language="de", latitude=latitude, longitude=longitude
+            )
         )
         payload = {"contamination": []}
         response = FakeResponse(payload)
@@ -217,12 +241,13 @@ class TestPollenApi(unittest.IsolatedAsyncioTestCase):
         url = session.get.call_args.args[0]
         self.assertIn(f"latitude={latitude}", url)
         self.assertIn(f"longitude={longitude}", url)
+        self.assertIn("lang=de", url)
         self.assertIn(f"apikey={api_key}", url)
 
     async def test_async_update_logs_error_with_redacted_url_and_cause(self):
         # Arrange
         hass = SimpleNamespace(
-            config=SimpleNamespace(latitude=48.2082, longitude=16.3738)
+            config=SimpleNamespace(language="de", latitude=48.2082, longitude=16.3738)
         )
         api_key = "secret-api-key"
         payload = {"contamination": []}

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -51,7 +51,9 @@ class TestPollenApiIntegration(unittest.IsolatedAsyncioTestCase):
         latitude = float(os.getenv("POLLEN_API_TEST_LATITUDE", "48.2082"))
         longitude = float(os.getenv("POLLEN_API_TEST_LONGITUDE", "16.3738"))
         hass = SimpleNamespace(
-            config=SimpleNamespace(latitude=latitude, longitude=longitude)
+            config=SimpleNamespace(
+                language="de", latitude=latitude, longitude=longitude
+            )
         )
         api = pollen_api_class(hass, api_key)
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -289,11 +289,17 @@ class TestPollenDataExtractorLogic(unittest.TestCase):
         extractor = self.PollenDataExtractor(coordinator, 23, "contamination_1")
         self.assertIsNone(extractor.get_native_value())
 
-    def test_extra_state_attributes_is_empty(self) -> None:
+    def test_extra_state_attributes_returns_matching_poll_title(self) -> None:
         coordinator = MagicMock()
-        coordinator.data = {"contamination": [{"poll_id": 23, "contamination_1": 5}]}
+        coordinator.data = {
+            "contamination": [
+                {"poll_id": 23, "contamination_1": 5, "poll_title": "Alternaria"}
+            ]
+        }
         extractor = self.PollenDataExtractor(coordinator, 23, "contamination_1")
-        self.assertEqual(extractor.get_extra_state_attributes(), {})
+        self.assertEqual(
+            extractor.get_extra_state_attributes(), {"poll_title": "Alternaria"}
+        )
 
 
 class TestAllergyriskDataExtractorLogic(unittest.TestCase):
@@ -359,6 +365,23 @@ class TestPollenSensorLogic(unittest.TestCase):
         )
         self.assertEqual(sensor.native_value, 5)
         self.assertEqual(sensor.state, 5)
+
+    def test_forecast_extra_state_attributes_returns_poll_title(self) -> None:
+        coordinator = MagicMock()
+        coordinator.data = {
+            "contamination": [
+                {"poll_id": 23, "contamination_2": 7, "poll_title": "Alternaria"}
+            ]
+        }
+        sensor = self.PollenSensor(
+            coordinator,
+            "alternaria",
+            23,
+            forecast_suffix="forecast1",
+            json_subelement_name="contamination_2",
+        )
+
+        self.assertEqual(sensor.extra_state_attributes, {"poll_title": "Alternaria"})
 
     def test_native_value_returns_none_when_pollen_id_not_found(self) -> None:
         coordinator = MagicMock()


### PR DESCRIPTION
* When calling the API set the lang query parameter to the Home Assistant system language when it is "en" or "de". Otherwise default to "en".
* Moved some intializations in PollenApi class to __init__ instead of doing it for every request.
* Added and adapted tests.