### PR TITLE
Better handling of API failures

### DIFF
--- a/custom_components/polleninformation_at/coordinator.py
+++ b/custom_components/polleninformation_at/coordinator.py
@@ -21,7 +21,6 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         """Initialize the coordinator."""
-        self.config_entry = config_entry
         super().__init__(
             hass,
             _LOGGER,
@@ -29,18 +28,17 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(hours=DEFAULT_INTERVAL),
         )
 
-    async def _async_update_data(self) -> dict:
-        """Fetch data from the upstream API."""
+        # Initialize the API handler with the API key from the config entry
+        self.config_entry = config_entry
         api_key = self.config_entry.options.get(
             CONF_API_KEY,
             self.config_entry.data.get(CONF_API_KEY),
         )
-        api = PollenApi(self.hass, api_key)
+        self._api = PollenApi(self.hass, api_key)
 
+    async def _async_update_data(self) -> dict:
+        """Fetch data from the upstream API."""
         try:
-            await api.async_update()
-        except Exception as err:
-            msg = f"Error fetching pollen data: {err}"
-            raise UpdateFailed(msg) from err
-
-        return api.raw_response or {}
+            return await self._api.async_update()
+        except RuntimeError as err:
+            raise UpdateFailed(str(err)) from err

--- a/custom_components/polleninformation_at/sensor.py
+++ b/custom_components/polleninformation_at/sensor.py
@@ -220,6 +220,17 @@ class CoordinatorSensor(SensorAttributesMixin, CoordinatorEntity, SensorEntity):
         self._initialize_sensor_attributes(name_suffix, forecast_suffix, icon)
 
     @property
+    def available(self) -> bool:
+        """
+        Return whether coordinator data is available.
+
+        By default the sensor becomes unavailable if the last coordinator update failed.
+        We want to override this behavior to make the sensor available even if the last
+        update failed, as long as we have valid data from a previous successful update.
+        """
+        return self.coordinator.data is not None
+
+    @property
     def native_value(self) -> int | None:
         """Return the current contamination level."""
         return self.data_extractor.get_native_value()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -173,14 +173,13 @@ class TestPollenDataUpdateCoordinator(unittest.IsolatedAsyncioTestCase):
         """Test that options API key takes precedence over data API key."""
         hass = MagicMock()
         entry = self._entry(data_api_key="data-key", options_api_key="options-key")
-        coordinator = PollenDataUpdateCoordinator(hass, entry)
 
         with patch(
             "custom_components.polleninformation_at.coordinator.PollenApi"
         ) as mock_api_cls:
+            coordinator = PollenDataUpdateCoordinator(hass, entry)
             api_instance = mock_api_cls.return_value
             api_instance.async_update = AsyncMock()
-            api_instance.raw_response = {"contamination": []}
 
             await coordinator._async_update_data()  # noqa: SLF001
 
@@ -191,34 +190,63 @@ class TestPollenDataUpdateCoordinator(unittest.IsolatedAsyncioTestCase):
         """Test that the coordinator returns raw API response on success."""
         hass = MagicMock()
         entry = self._entry()
-        coordinator = PollenDataUpdateCoordinator(hass, entry)
 
         with patch(
             "custom_components.polleninformation_at.coordinator.PollenApi"
         ) as mock_api_cls:
+            coordinator = PollenDataUpdateCoordinator(hass, entry)
             api_instance = mock_api_cls.return_value
-            api_instance.async_update = AsyncMock()
-            api_instance.raw_response = {"contamination": [{"poll_id": 23}]}
+            api_instance.async_update = AsyncMock(
+                return_value={"contamination": [{"poll_id": 23}]}
+            )
 
             data = await coordinator._async_update_data()  # noqa: SLF001
 
         self.assertEqual(data, {"contamination": [{"poll_id": 23}]})  # noqa: PT009
 
-    async def test_wraps_api_error_in_update_failed(self) -> None:
-        """Test that API errors are wrapped in UpdateFailed."""
+    async def test_reuses_api_client_for_multiple_updates(self) -> None:
+        """Test that updates reuse the API client created by the coordinator."""
         hass = MagicMock()
         entry = self._entry()
-        coordinator = PollenDataUpdateCoordinator(hass, entry)
 
         with patch(
             "custom_components.polleninformation_at.coordinator.PollenApi"
         ) as mock_api_cls:
+            coordinator = PollenDataUpdateCoordinator(hass, entry)
+            api_instance = mock_api_cls.return_value
+            api_instance.async_update = AsyncMock(
+                side_effect=[
+                    {"contamination": [{"poll_id": 23}]},
+                    {"contamination": [{"poll_id": 24}]},
+                ]
+            )
+
+            first_data = await coordinator._async_update_data()  # noqa: SLF001
+            second_data = await coordinator._async_update_data()  # noqa: SLF001
+
+        mock_api_cls.assert_called_once_with(hass, "data-key")
+        assert first_data == {"contamination": [{"poll_id": 23}]}
+        assert second_data == {"contamination": [{"poll_id": 24}]}
+        assert api_instance.async_update.await_count == 2
+
+    async def test_wraps_api_error_in_update_failed(self) -> None:
+        """Test that API errors are wrapped in UpdateFailed."""
+        hass = MagicMock()
+        entry = self._entry()
+        previous_data = {"contamination": [{"poll_id": 23}]}
+
+        with patch(
+            "custom_components.polleninformation_at.coordinator.PollenApi"
+        ) as mock_api_cls:
+            coordinator = PollenDataUpdateCoordinator(hass, entry)
+            coordinator.data = previous_data
             api_instance = mock_api_cls.return_value
             api_instance.async_update = AsyncMock(side_effect=RuntimeError("boom"))
-            api_instance.raw_response = None
 
-            with self.assertRaises(UpdateFailed):  # noqa: PT027
+            with self.assertRaisesRegex(UpdateFailed, "boom"):
                 await coordinator._async_update_data()  # noqa: SLF001
+
+            assert coordinator.data == previous_data
 
 
 if __name__ == "__main__":

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -258,6 +258,20 @@ class TestCoordinatorSensorLogic(unittest.TestCase):
         self.assertEqual(sensor._attr_native_unit_of_measurement, "level")
         self.assertTrue(sensor._attr_has_entity_name)
 
+    def test_exposes_cached_value_after_failed_update(self) -> None:
+        """Expose the cached value when the latest coordinator update failed."""
+        sensor = self._make_sensor({"test_series_1": 4})
+        sensor.coordinator.last_update_success = False
+
+        assert sensor.available
+        assert sensor.native_value == 4
+
+    def test_unavailable_when_coordinator_has_no_data(self) -> None:
+        """Mark sensors unavailable before the first successful update."""
+        sensor = self._make_sensor(None)
+
+        assert not sensor.available
+
 
 class TestPollenDataExtractorLogic(unittest.TestCase):
     """Tests for the pollen data extraction logic."""


### PR DESCRIPTION
* Keep sensors available if last coordinator update failed
* Sensors keep showing last good coordinator value even if update failed
* Tests